### PR TITLE
Rx perf improvement

### DIFF
--- a/src/Xmf2.Rx.Droid/BaseView/ReactiveLinearLayout.cs
+++ b/src/Xmf2.Rx.Droid/BaseView/ReactiveLinearLayout.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reactive;
 using System.Reactive.Concurrency;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Android.Content;
 using Android.Runtime;
@@ -52,20 +53,20 @@ namespace Xmf2.Rx.Droid.BaseView
 			set => ViewModel = value as TViewModel;
 		}
 
-		private readonly Subject<Unit> activated = new Subject<Unit>();
-		public new IObservable<Unit> Activated => activated;
+		readonly Subject<Unit> _activated = new Subject<Unit>();
+		public new IObservable<Unit> Activated => _activated.AsObservable();
 
-		private readonly Subject<Unit> deactivated = new Subject<Unit>();
-		public IObservable<Unit> Deactivated => deactivated;
+		readonly Subject<Unit> _deactivated = new Subject<Unit>();
+		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
 
 		public void Activate()
 		{
-			RxApp.TaskpoolScheduler.Schedule(() => (activated).OnNext(Unit.Default));
+			_activated.OnNext(Unit.Default);
 		}
 
 		public void Deactivate()
 		{
-			RxApp.TaskpoolScheduler.Schedule(() => (deactivated).OnNext(Unit.Default));
+			_deactivated.OnNext(Unit.Default);
 		}
 
 		#endregion

--- a/src/Xmf2.Rx.Droid/BaseView/ReactiveLinearLayout.cs
+++ b/src/Xmf2.Rx.Droid/BaseView/ReactiveLinearLayout.cs
@@ -8,6 +8,7 @@ using Android.Runtime;
 using Android.Util;
 using Android.Widget;
 using ReactiveUI;
+using Xmf2.Rx.Helpers;
 
 namespace Xmf2.Rx.Droid.BaseView
 {
@@ -53,21 +54,15 @@ namespace Xmf2.Rx.Droid.BaseView
 			set => ViewModel = value as TViewModel;
 		}
 
-		readonly Subject<Unit> _activated = new Subject<Unit>();
-		public new IObservable<Unit> Activated => _activated.AsObservable();
+		private readonly CanActivateImplementation _activationImpl = new CanActivateImplementation();
 
-		readonly Subject<Unit> _deactivated = new Subject<Unit>();
-		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
+		public new IObservable<Unit> Activated => _activationImpl.Activated;
 
-		public void Activate()
-		{
-			_activated.OnNext(Unit.Default);
-		}
+		public IObservable<Unit> Deactivated => _activationImpl.Deactivated;
 
-		public void Deactivate()
-		{
-			_deactivated.OnNext(Unit.Default);
-		}
+		public void Activate() => _activationImpl.Activate();
+
+		public void Deactivate() => _activationImpl.Deactivate();
 
 		#endregion
 

--- a/src/Xmf2.Rx.Droid/BaseView/ReactiveLinearLayout.cs
+++ b/src/Xmf2.Rx.Droid/BaseView/ReactiveLinearLayout.cs
@@ -60,12 +60,12 @@ namespace Xmf2.Rx.Droid.BaseView
 
 		public void Activate()
 		{
-			RxApp.MainThreadScheduler.Schedule(() => (activated).OnNext(Unit.Default));
+			RxApp.TaskpoolScheduler.Schedule(() => (activated).OnNext(Unit.Default));
 		}
 
 		public void Deactivate()
 		{
-			RxApp.MainThreadScheduler.Schedule(() => (deactivated).OnNext(Unit.Default));
+			RxApp.TaskpoolScheduler.Schedule(() => (deactivated).OnNext(Unit.Default));
 		}
 
 		#endregion

--- a/src/Xmf2.Rx.Droid/BaseView/XMFAppCompatActivity.cs
+++ b/src/Xmf2.Rx.Droid/BaseView/XMFAppCompatActivity.cs
@@ -108,13 +108,13 @@ namespace Xmf2.Rx.Droid.BaseView
 		protected override void OnPause()
 		{
 			base.OnPause();
-			RxApp.TaskpoolScheduler.Schedule(() => _deactivated.OnNext(Unit.Default));
+			_deactivated.OnNext(Unit.Default);
 		}
 
 		protected override void OnResume()
 		{
 			base.OnResume();
-			RxApp.TaskpoolScheduler.Schedule(() => _activated.OnNext(Unit.Default));
+			_activated.OnNext(Unit.Default);
 		}
 
 		readonly Subject<Tuple<int, Result, Intent>> activityResult = new Subject<Tuple<int, Result, Intent>>();

--- a/src/Xmf2.Rx.Droid/BaseView/XMFAppCompatActivity.cs
+++ b/src/Xmf2.Rx.Droid/BaseView/XMFAppCompatActivity.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
@@ -98,22 +99,22 @@ namespace Xmf2.Rx.Droid.BaseView
 
 		public IObservable<Exception> ThrownExceptions => this.getThrownExceptionsObservable();
 
-		readonly Subject<Unit> activated = new Subject<Unit>();
-		public IObservable<Unit> Activated => activated.AsObservable();
+		readonly Subject<Unit> _activated = new Subject<Unit>();
+		public IObservable<Unit> Activated => _activated.AsObservable();
 
-		readonly Subject<Unit> deactivated = new Subject<Unit>();
-		public IObservable<Unit> Deactivated => deactivated.AsObservable();
+		readonly Subject<Unit> _deactivated = new Subject<Unit>();
+		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
 
 		protected override void OnPause()
 		{
 			base.OnPause();
-			deactivated.OnNext(Unit.Default);
+			RxApp.TaskpoolScheduler.Schedule(() => _deactivated.OnNext(Unit.Default));
 		}
 
 		protected override void OnResume()
 		{
 			base.OnResume();
-			activated.OnNext(Unit.Default);
+			RxApp.TaskpoolScheduler.Schedule(() => _activated.OnNext(Unit.Default));
 		}
 
 		readonly Subject<Tuple<int, Result, Intent>> activityResult = new Subject<Tuple<int, Result, Intent>>();

--- a/src/Xmf2.Rx.Droid/BaseView/XMFAppCompatActivity.cs
+++ b/src/Xmf2.Rx.Droid/BaseView/XMFAppCompatActivity.cs
@@ -21,7 +21,7 @@ namespace Xmf2.Rx.Droid.BaseView
 	/// This is an Activity that is both an Activity and has ReactiveObject powers 
 	/// (i.e. you can call RaiseAndSetIfChanged)
 	/// </summary>
-	public class XMFAppCompatActivity<TViewModel> : ReactiveAppCompatActivity, IViewFor<TViewModel>, ICanActivate
+	public class XMFAppCompatActivity<TViewModel> : ReactiveAppCompatActivity, IViewFor<TViewModel>
 		where TViewModel : class
 	{
 		protected XMFAppCompatActivity() { }
@@ -46,7 +46,7 @@ namespace Xmf2.Rx.Droid.BaseView
 	/// This is an Activity that is both an Activity and has ReactiveObject powers 
 	/// (i.e. you can call RaiseAndSetIfChanged)
 	/// </summary>
-	public class ReactiveAppCompatActivity : AppCompatActivity, IReactiveObject, IReactiveNotifyPropertyChanged<ReactiveAppCompatActivity>, IHandleObservableErrors
+	public class ReactiveAppCompatActivity : AppCompatActivity, IReactiveObject, IReactiveNotifyPropertyChanged<ReactiveAppCompatActivity>, IHandleObservableErrors, ICanActivate
 	{
 		protected ReactiveAppCompatActivity() { }
 
@@ -99,22 +99,22 @@ namespace Xmf2.Rx.Droid.BaseView
 
 		public IObservable<Exception> ThrownExceptions => this.getThrownExceptionsObservable();
 
-		readonly Subject<Unit> _activated = new Subject<Unit>();
-		public IObservable<Unit> Activated => _activated.AsObservable();
+		private readonly CanActivateImplementation _activationImplementation = new CanActivateImplementation();
 
-		readonly Subject<Unit> _deactivated = new Subject<Unit>();
-		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
+		public IObservable<Unit> Activated => _activationImplementation.Activated;
+
+		public IObservable<Unit> Deactivated => _activationImplementation.Deactivated;
 
 		protected override void OnPause()
 		{
 			base.OnPause();
-			_deactivated.OnNext(Unit.Default);
+			_activationImplementation.Deactivate();
 		}
 
 		protected override void OnResume()
 		{
 			base.OnResume();
-			_activated.OnNext(Unit.Default);
+			_activationImplementation.Activate();
 		}
 
 		readonly Subject<Tuple<int, Result, Intent>> activityResult = new Subject<Tuple<int, Result, Intent>>();

--- a/src/Xmf2.Rx.Droid/BaseView/XMFReactiveDialogFragment.cs
+++ b/src/Xmf2.Rx.Droid/BaseView/XMFReactiveDialogFragment.cs
@@ -15,7 +15,7 @@ namespace Xmf2.Rx.Droid.BaseView
 	/// This is a DialogFragment that is both a DialogFragment and has ReactiveObject powers 
 	/// (i.e. you can call RaiseAndSetIfChanged)
 	/// </summary>
-	public class XMFReactiveDialogFragment<TViewModel> : XMFReactiveDialogFragment, IViewFor<TViewModel>, ICanActivate
+	public class XMFReactiveDialogFragment<TViewModel> : XMFReactiveDialogFragment, IViewFor<TViewModel>
 		where TViewModel : class
 	{
 		protected XMFReactiveDialogFragment()
@@ -46,7 +46,7 @@ namespace Xmf2.Rx.Droid.BaseView
 	/// (i.e. you can call RaiseAndSetIfChanged)
 	/// </summary>
 	public class XMFReactiveDialogFragment : Android.Support.V4.App.DialogFragment,
-		IReactiveNotifyPropertyChanged<XMFReactiveDialogFragment>, IReactiveObject, IHandleObservableErrors
+		IReactiveNotifyPropertyChanged<XMFReactiveDialogFragment>, IReactiveObject, IHandleObservableErrors, ICanActivate
 	{
 		protected XMFReactiveDialogFragment()
 		{
@@ -114,22 +114,22 @@ namespace Xmf2.Rx.Droid.BaseView
 
 		public IObservable<Exception> ThrownExceptions => this.getThrownExceptionsObservable();
 
-		readonly Subject<Unit> _activated = new Subject<Unit>();
-		public IObservable<Unit> Activated => _activated.AsObservable();
+		private readonly CanActivateImplementation _activationImplementation = new CanActivateImplementation();
 
-		readonly Subject<Unit> _deactivated = new Subject<Unit>();
-		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
+		public IObservable<Unit> Activated => _activationImplementation.Activated;
+
+		public IObservable<Unit> Deactivated => _activationImplementation.Deactivated;
 
 		public override void OnPause()
 		{
 			base.OnPause();
-			_deactivated.OnNext(Unit.Default);
+			_activationImplementation.Deactivate();
 		}
 
 		public override void OnResume()
 		{
 			base.OnResume();
-			_activated.OnNext(Unit.Default);
+			_activationImplementation.Activate();
 		}
 	}
 }

--- a/src/Xmf2.Rx.Droid/BaseView/XMFReactiveDialogFragment.cs
+++ b/src/Xmf2.Rx.Droid/BaseView/XMFReactiveDialogFragment.cs
@@ -114,24 +114,22 @@ namespace Xmf2.Rx.Droid.BaseView
 
 		public IObservable<Exception> ThrownExceptions => this.getThrownExceptionsObservable();
 
-		readonly Subject<Unit> activated = new Subject<Unit>();
+		readonly Subject<Unit> _activated = new Subject<Unit>();
+		public IObservable<Unit> Activated => _activated.AsObservable();
 
-		public IObservable<Unit> Activated => activated.AsObservable();
-
-		readonly Subject<Unit> deactivated = new Subject<Unit>();
-
-		public IObservable<Unit> Deactivated => deactivated.AsObservable();
+		readonly Subject<Unit> _deactivated = new Subject<Unit>();
+		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
 
 		public override void OnPause()
 		{
 			base.OnPause();
-			deactivated.OnNext(Unit.Default);
+			_deactivated.OnNext(Unit.Default);
 		}
 
 		public override void OnResume()
 		{
 			base.OnResume();
-			activated.OnNext(Unit.Default);
+			_activated.OnNext(Unit.Default);
 		}
 	}
 }

--- a/src/Xmf2.Rx.Droid/ChipClouds/BaseReactiveChipCloudViewHolder.cs
+++ b/src/Xmf2.Rx.Droid/ChipClouds/BaseReactiveChipCloudViewHolder.cs
@@ -22,6 +22,10 @@ namespace Xmf2.Rx.Droid.ChipClouds
 			set
 			{
 				_viewModel = value;
+				if (value != null)
+				{
+					OnViewModelSet();
+				}
 				Activate();
 			}
 		}
@@ -47,6 +51,8 @@ namespace Xmf2.Rx.Droid.ChipClouds
 			SetViewModelBindings();
 			ItemView.Click += OnClickItem;
 		}
+
+		protected virtual void OnViewModelSet() { }
 
 		protected virtual void OnContentViewSet() { }
 

--- a/src/Xmf2.Rx.Droid/ChipClouds/BaseReactiveChipCloudViewHolder.cs
+++ b/src/Xmf2.Rx.Droid/ChipClouds/BaseReactiveChipCloudViewHolder.cs
@@ -8,10 +8,12 @@ using Android.Content;
 using Android.Views;
 using ReactiveUI;
 using Xmf2.Commons.Droid.ChipClouds;
+using Xmf2.Rx.Helpers;
 
 namespace Xmf2.Rx.Droid.ChipClouds
 {
-	public class BaseReactiveChipCloudViewHolder<TViewModel> : ChipCloudViewHolder, IViewFor<TViewModel>, IViewFor, ICanActivate where TViewModel : class, IReactiveObject 
+	public class BaseReactiveChipCloudViewHolder<TViewModel> : ChipCloudViewHolder, IViewFor<TViewModel>, IViewFor, ICanActivate 
+		where TViewModel : class, IReactiveObject 
 	{
 		public readonly Context Context;
 
@@ -26,7 +28,6 @@ namespace Xmf2.Rx.Droid.ChipClouds
 				{
 					OnViewModelSet();
 				}
-				Activate();
 			}
 		}
 
@@ -36,11 +37,11 @@ namespace Xmf2.Rx.Droid.ChipClouds
 			set => ViewModel = value as TViewModel;
 		}
 
-		readonly Subject<Unit> _activated = new Subject<Unit>();
-		public IObservable<Unit> Activated => _activated.AsObservable();
+		private readonly CanActivateImplementation _activationImplementation = new CanActivateImplementation();
 
-		readonly Subject<Unit> _deactivated = new Subject<Unit>();
-		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
+		public IObservable<Unit> Activated => _activationImplementation.Activated;
+
+		public IObservable<Unit> Deactivated => _activationImplementation.Deactivated;
 
 		public ICommand ItemClick { get; set; }
 
@@ -67,22 +68,12 @@ namespace Xmf2.Rx.Droid.ChipClouds
 
 		public override void OnViewAttachedToWindow()
 		{
-			Activate();
+			_activationImplementation.Activate();
 		}
 
 		public override void OnViewDetachedFromWindow()
 		{
-			Deactivate();
-		}
-
-		public void Activate()
-		{
-			_activated.OnNext(Unit.Default);
-		}
-
-		public void Deactivate()
-		{
-			_deactivated.OnNext(Unit.Default);
+			_activationImplementation.Deactivate();
 		}
 		
 		#endregion

--- a/src/Xmf2.Rx.Droid/ChipClouds/BaseReactiveChipCloudViewHolder.cs
+++ b/src/Xmf2.Rx.Droid/ChipClouds/BaseReactiveChipCloudViewHolder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reactive;
 using System.Reactive.Concurrency;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Windows.Input;
 using Android.Content;
@@ -31,11 +32,11 @@ namespace Xmf2.Rx.Droid.ChipClouds
 			set => ViewModel = value as TViewModel;
 		}
 
-		private readonly Subject<Unit> activated = new Subject<Unit>();
-		public IObservable<Unit> Activated => activated;
+		readonly Subject<Unit> _activated = new Subject<Unit>();
+		public IObservable<Unit> Activated => _activated.AsObservable();
 
-		private readonly Subject<Unit> deactivated = new Subject<Unit>();
-		public IObservable<Unit> Deactivated => deactivated;
+		readonly Subject<Unit> _deactivated = new Subject<Unit>();
+		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
 
 		public ICommand ItemClick { get; set; }
 
@@ -70,14 +71,14 @@ namespace Xmf2.Rx.Droid.ChipClouds
 
 		public void Activate()
 		{
-			RxApp.MainThreadScheduler.Schedule(() => (activated).OnNext(Unit.Default));
+			_activated.OnNext(Unit.Default);
 		}
 
 		public void Deactivate()
 		{
-			RxApp.MainThreadScheduler.Schedule(() => (deactivated).OnNext(Unit.Default));
+			_deactivated.OnNext(Unit.Default);
 		}
-
+		
 		#endregion
 
 		public override void Dispose()

--- a/src/Xmf2.Rx.Droid/LinearList/BaseReactiveLinearLayoutViewViewHolder.cs
+++ b/src/Xmf2.Rx.Droid/LinearList/BaseReactiveLinearLayoutViewViewHolder.cs
@@ -6,25 +6,27 @@ using System.Reactive.Subjects;
 using Android.Views;
 using ReactiveUI;
 using Xmf2.Commons.Droid.LinearList;
+using Xmf2.Rx.Helpers;
 
 namespace Xmf2.Rx.Droid.LinearList
 {
-	public class BaseReactiveLinearLayoutViewViewHolder<TViewModel> : LinearListViewHolder, IViewFor<TViewModel>, IViewFor, ICanActivate where TViewModel : class, IReactiveObject
+	public class BaseReactiveLinearLayoutViewViewHolder<TViewModel> : LinearListViewHolder, IViewFor<TViewModel>, IViewFor, ICanActivate 
+		where TViewModel : class, IReactiveObject
 	{
-		readonly Subject<Unit> _activated = new Subject<Unit>();
-		public IObservable<Unit> Activated => _activated.AsObservable();
+		private readonly CanActivateImplementation _activationImplementation = new CanActivateImplementation();
 
-		readonly Subject<Unit> _deactivated = new Subject<Unit>();
-		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
+		public IObservable<Unit> Activated => _activationImplementation.Activated;
+
+		public IObservable<Unit> Deactivated => _activationImplementation.Deactivated;
 
 		public void Activate()
 		{
-			_activated.OnNext(Unit.Default);
+			_activationImplementation.Activate();
 		}
 
 		public void Deactivate()
 		{
-			_deactivated.OnNext(Unit.Default);
+			_activationImplementation.Deactivate();
 		}
 
 		public TViewModel ViewModel

--- a/src/Xmf2.Rx.Droid/LinearList/BaseReactiveLinearLayoutViewViewHolder.cs
+++ b/src/Xmf2.Rx.Droid/LinearList/BaseReactiveLinearLayoutViewViewHolder.cs
@@ -18,12 +18,12 @@ namespace Xmf2.Rx.Droid.LinearList
 
 		public void Activate()
 		{
-			RxApp.MainThreadScheduler.Schedule(() => (activated).OnNext(Unit.Default));
+			RxApp.TaskpoolScheduler.Schedule(() => (activated).OnNext(Unit.Default));
 		}
 
 		public void Deactivate()
 		{
-			RxApp.MainThreadScheduler.Schedule(() => (deactivated).OnNext(Unit.Default));
+			RxApp.TaskpoolScheduler.Schedule(() => (deactivated).OnNext(Unit.Default));
 		}
 
 		public TViewModel ViewModel

--- a/src/Xmf2.Rx.Droid/LinearList/BaseReactiveLinearLayoutViewViewHolder.cs
+++ b/src/Xmf2.Rx.Droid/LinearList/BaseReactiveLinearLayoutViewViewHolder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reactive;
 using System.Reactive.Concurrency;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Android.Views;
 using ReactiveUI;
@@ -10,20 +11,20 @@ namespace Xmf2.Rx.Droid.LinearList
 {
 	public class BaseReactiveLinearLayoutViewViewHolder<TViewModel> : LinearListViewHolder, IViewFor<TViewModel>, IViewFor, ICanActivate where TViewModel : class, IReactiveObject
 	{
-		private readonly Subject<Unit> activated = new Subject<Unit>();
-		public IObservable<Unit> Activated => activated;
+		readonly Subject<Unit> _activated = new Subject<Unit>();
+		public IObservable<Unit> Activated => _activated.AsObservable();
 
-		private readonly Subject<Unit> deactivated = new Subject<Unit>();
-		public IObservable<Unit> Deactivated => deactivated;
+		readonly Subject<Unit> _deactivated = new Subject<Unit>();
+		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
 
 		public void Activate()
 		{
-			RxApp.TaskpoolScheduler.Schedule(() => (activated).OnNext(Unit.Default));
+			_activated.OnNext(Unit.Default);
 		}
 
 		public void Deactivate()
 		{
-			RxApp.TaskpoolScheduler.Schedule(() => (deactivated).OnNext(Unit.Default));
+			_deactivated.OnNext(Unit.Default);
 		}
 
 		public TViewModel ViewModel

--- a/src/Xmf2.Rx.Droid/ListElement/BaseReactiveRecyclerViewViewHolder.cs
+++ b/src/Xmf2.Rx.Droid/ListElement/BaseReactiveRecyclerViewViewHolder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reactive;
 using System.Reactive.Concurrency;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Windows.Input;
 using Android.Content;
@@ -14,11 +15,11 @@ namespace Xmf2.Rx.Droid.ListElement
 	{
 		protected Context Context { get; }
 
-		private readonly Subject<Unit> activated = new Subject<Unit>();
-		public IObservable<Unit> Activated => activated;
+		readonly Subject<Unit> _activated = new Subject<Unit>();
+		public IObservable<Unit> Activated => _activated.AsObservable();
 
-		private readonly Subject<Unit> deactivated = new Subject<Unit>();
-		public IObservable<Unit> Deactivated => deactivated;
+		readonly Subject<Unit> _deactivated = new Subject<Unit>();
+		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
 
 		public ICommand ItemClick { get; set; }
 
@@ -71,12 +72,12 @@ namespace Xmf2.Rx.Droid.ListElement
 
 		public void OnViewAttachedToWindow()
 		{
-			RxApp.TaskpoolScheduler.Schedule(() => (activated).OnNext(Unit.Default));
+			_activated.OnNext(Unit.Default);
 		}
 
 		public void OnViewDetachedFromWindow()
 		{
-			RxApp.TaskpoolScheduler.Schedule(() => (deactivated).OnNext(Unit.Default));
+			_deactivated.OnNext(Unit.Default);
 		}
 
 		public virtual void OnViewRecycled() { }

--- a/src/Xmf2.Rx.Droid/ListElement/BaseReactiveRecyclerViewViewHolder.cs
+++ b/src/Xmf2.Rx.Droid/ListElement/BaseReactiveRecyclerViewViewHolder.cs
@@ -8,18 +8,20 @@ using Android.Content;
 using Android.Views;
 using ReactiveUI;
 using ReactiveUI.Android.Support;
+using Xmf2.Rx.Helpers;
 
 namespace Xmf2.Rx.Droid.ListElement
 {
-	public class BaseReactiveRecyclerViewViewHolder<TViewModel> : XMF2ReactiveRecyclerViewViewHolder<TViewModel>, ICanActivate, IRecyclerViewViewHolder where TViewModel : class, IReactiveObject
+	public class BaseReactiveRecyclerViewViewHolder<TViewModel> : XMF2ReactiveRecyclerViewViewHolder<TViewModel>, ICanActivate, IRecyclerViewViewHolder 
+		where TViewModel : class, IReactiveObject
 	{
 		protected Context Context { get; }
 
-		readonly Subject<Unit> _activated = new Subject<Unit>();
-		public IObservable<Unit> Activated => _activated.AsObservable();
+		private readonly CanActivateImplementation _activationImplementation = new CanActivateImplementation();
 
-		readonly Subject<Unit> _deactivated = new Subject<Unit>();
-		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
+		public IObservable<Unit> Activated => _activationImplementation.Activated;
+
+		public IObservable<Unit> Deactivated => _activationImplementation.Deactivated;
 
 		public ICommand ItemClick { get; set; }
 
@@ -72,12 +74,12 @@ namespace Xmf2.Rx.Droid.ListElement
 
 		public void OnViewAttachedToWindow()
 		{
-			_activated.OnNext(Unit.Default);
+			_activationImplementation.Activate();
 		}
 
 		public void OnViewDetachedFromWindow()
 		{
-			_deactivated.OnNext(Unit.Default);
+			_activationImplementation.Deactivate();
 		}
 
 		public virtual void OnViewRecycled() { }

--- a/src/Xmf2.Rx.Droid/ListElement/BaseReactiveRecyclerViewViewHolder.cs
+++ b/src/Xmf2.Rx.Droid/ListElement/BaseReactiveRecyclerViewViewHolder.cs
@@ -71,12 +71,12 @@ namespace Xmf2.Rx.Droid.ListElement
 
 		public void OnViewAttachedToWindow()
 		{
-			RxApp.MainThreadScheduler.Schedule(() => (activated).OnNext(Unit.Default));
+			RxApp.TaskpoolScheduler.Schedule(() => (activated).OnNext(Unit.Default));
 		}
 
 		public void OnViewDetachedFromWindow()
 		{
-			RxApp.MainThreadScheduler.Schedule(() => (deactivated).OnNext(Unit.Default));
+			RxApp.TaskpoolScheduler.Schedule(() => (deactivated).OnNext(Unit.Default));
 		}
 
 		public virtual void OnViewRecycled() { }

--- a/src/Xmf2.Rx/Helpers/CanActivateImplementation.cs
+++ b/src/Xmf2.Rx/Helpers/CanActivateImplementation.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using ReactiveUI;
+
+namespace Xmf2.Rx.Helpers
+{
+	public class CanActivateImplementation : ICanActivate
+	{
+		private readonly Subject<Unit> _activated = new Subject<Unit>();
+		private readonly Subject<Unit> _deactivated = new Subject<Unit>();
+
+		public IObservable<Unit> Activated => _activated.AsObservable();
+
+		public IObservable<Unit> Deactivated => _deactivated.AsObservable();
+
+		public void Activate()
+		{
+			RxApp.TaskpoolScheduler.Schedule(() => _activated.OnNext(Unit.Default));
+		}
+
+		public void Deactivate()
+		{
+			RxApp.TaskpoolScheduler.Schedule(() => _deactivated.OnNext(Unit.Default));
+		}
+	}
+}


### PR DESCRIPTION
Modification Android pour le problème de nombre de Thread et de trop de tâche sur le main thread.
Revois principalement l'implémentation de ICanActivate dans la plupart des classes de Rx pour Android + nos classes custom.

Pour iOS, il serait pas mal d'aller voir dans le code Rx pour valider que les Activate/Deactivate ne se font pas sur le MainThread.

Risques : 
  - Déplacer le WhenActivated pour s'exécuter dans le TaskPool au lieu du MainThread ne permet plus d'avoir accès aux éléments UI. => Tous les abonnements sur les events devront être revu pour être eux passé sur le main thread. 