### PR TITLE
Fix handle invalid token by logout

### DIFF
--- a/src/Xmf2.Commons/OAuth2/AuthErrorReason.cs
+++ b/src/Xmf2.Commons/OAuth2/AuthErrorReason.cs
@@ -6,6 +6,7 @@ namespace Xmf2.Rest.OAuth2
 		ServerError,
 		InvalidCredentials,
 		BadRequest,
-		InvalidAppVersion
+		InvalidAppVersion,
+		InvalidToken
 	}
 }

--- a/src/Xmf2.Commons/OAuth2/OAuth2ConfigurationBase.cs
+++ b/src/Xmf2.Commons/OAuth2/OAuth2ConfigurationBase.cs
@@ -28,12 +28,12 @@ namespace Xmf2.Rest.OAuth2
 	{
 		public override OAuth2AuthResult HandleAuthResult(IRestResponse response)
 		{
+			string content = response.Content;
+			TAuthRequestResponse responseResult = JsonConvert.DeserializeObject<TAuthRequestResponse>(content);
+
+			OAuth2AuthResult result = HandleAuthResult(responseResult);
 			if (response.IsSuccess)
 			{
-				string content = response.Content;
-				TAuthRequestResponse responseResult = JsonConvert.DeserializeObject<TAuthRequestResponse>(content);
-
-				OAuth2AuthResult result = HandleAuthResult(responseResult);
 				result.IsSuccess = true;
 				return result;
 			}
@@ -44,7 +44,7 @@ namespace Xmf2.Rest.OAuth2
 					return new OAuth2AuthResult
 					{
 						IsSuccess = false,
-						ErrorReason = AuthErrorReason.InvalidCredentials,
+						ErrorReason = result.ErrorMessage == "Invalid token" ? AuthErrorReason.InvalidToken : AuthErrorReason.InvalidCredentials, //API à modifier pour avoir un error_code plus precis lors d'un token invalid 
 						ErrorMessage = response.Content,
 					};
 				case HttpStatusCode.BadRequest:

--- a/src/Xmf2.Commons/OAuth2/OAuth2RestClient.cs
+++ b/src/Xmf2.Commons/OAuth2/OAuth2RestClient.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using RestSharp.Portable;
+using Xmf2.Commons.Exceptions;
 using Xmf2.Rest.HttpClient.Impl;
 using RestClientExtensions = Xmf2.Rest.HttpClient.RestClientExtensions;
 
@@ -177,7 +178,7 @@ namespace Xmf2.Rest.OAuth2
 				authenticator.Access = result;
 				Authenticator = OAuth2Authenticator = authenticator;
 			}
-			else if(result.ErrorReason == AuthErrorReason.InvalidCredentials)
+			else if (result.ErrorReason == AuthErrorReason.InvalidCredentials || result.ErrorReason == AuthErrorReason.InvalidToken)
 			{
 				Logout();
 			}
@@ -190,8 +191,8 @@ namespace Xmf2.Rest.OAuth2
 	    {
 		    Authenticator = null;
 		    OAuth2Authenticator = null;
-	    }
-		
+		}
+
 		public override async Task<IRestResponse<T>> Execute<T>(IRestRequest request, CancellationToken ct)
 		{
 			using (IHttpResponseMessage response = await ExecuteRequest(request, ct).ConfigureAwait(false))

--- a/src/Xmf2.Rx/Services/Authentications/AuthenticationService.cs
+++ b/src/Xmf2.Rx/Services/Authentications/AuthenticationService.cs
@@ -57,6 +57,10 @@ namespace Xmf2.Rx.Services.Authentications
 			{
 				throw new InvalidAppVersionException();
 			}
+			else if (e.ErrorReason == AuthErrorReason.InvalidToken)
+			{
+				throw new AccessDataException(AccessDataException.ErrorType.UnAuthorized);
+			}
 		}
 
 		public IObservable<bool> LoginWithCredentials(string login, string password)


### PR DESCRIPTION
Pour plus de propreté, une partie du fix devrait être apportée à l'api
API à modifier pour avoir un error_code plus précis lors d'un token invalid 