### PR TITLE
Feat/update mvvmcross for androidx

### DIFF
--- a/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.DroidAppCompat/Target/BackgroundTintDrawableNameTargetBinding.cs
+++ b/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.DroidAppCompat/Target/BackgroundTintDrawableNameTargetBinding.cs
@@ -1,7 +1,7 @@
-using Android.Content.Res;
 using Android.Views;
-using Android.Support.V4.View;
+using Android.Content.Res;
 using MvvmCross.Platforms.Android.Binding.Target;
+using AndroidX.Core.View;
 
 namespace Xmf2.Commons.MvxExtends.DroidAppCompat.Target
 {

--- a/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.DroidAppCompat/Views/BaseView.cs
+++ b/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.DroidAppCompat/Views/BaseView.cs
@@ -1,11 +1,11 @@
 using System;
 using Xmf2.Commons.Subscriptions;
 using Xmf2.Commons.MvxExtends.ViewModels;
-using MvvmCross.Droid.Support.V7.AppCompat;
+using MvvmCross.Platforms.Android.Views;
 
 namespace Xmf2.Commons.MvxExtends.DroidAppCompat.Views
 {
-	public abstract class BaseView<TViewModel, TParameter> : MvxAppCompatActivity<TViewModel> where TViewModel : BaseViewModel<TParameter> where TParameter : class
+	public abstract class BaseView<TViewModel, TParameter> : MvxActivity<TViewModel> where TViewModel : BaseViewModel<TParameter> where TParameter : class
 	{
 		protected Xmf2Disposable Disposable = new Xmf2Disposable();
 

--- a/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.DroidAppCompat/Views/PopupMenuLauncher.cs
+++ b/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.DroidAppCompat/Views/PopupMenuLauncher.cs
@@ -3,9 +3,9 @@ using Android.Util;
 using Android.Views;
 using Android.Content;
 using Android.Runtime;
-using Android.Support.V7.Widget;
 using MvvmCross.ViewModels;
 using Xmf2.Commons.MvxExtends.Interactions;
+using AndroidX.AppCompat.Widget;
 
 namespace Xmf2.Commons.MvxExtends.DroidAppCompat.Views
 {

--- a/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.DroidAppCompat/Xmf2.Commons.MvxExtends.DroidAppCompat.csproj
+++ b/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.DroidAppCompat/Xmf2.Commons.MvxExtends.DroidAppCompat.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -57,8 +57,13 @@
       <Name>Xmf2.Commons</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="MvvmCross.Droid.Support.V7.AppCompat" Version="6.4.2" />
+  <ItemGroup>    
+    <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />    
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.6.0.3" />
+    <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.3.1.2" />    
+    <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.3.6.3" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.3.1.1" />
+    <PackageReference Include="MvvmCross" Version="8.0.2" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.DroidAppCompat/Xmf2.Commons.MvxExtends.DroidAppCompat.csproj
+++ b/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.DroidAppCompat/Xmf2.Commons.MvxExtends.DroidAppCompat.csproj
@@ -58,12 +58,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>    
-    <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />    
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.6.0.3" />
-    <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.3.1.2" />    
-    <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.3.6.3" />
     <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.3.1.1" />
-    <PackageReference Include="MvvmCross" Version="8.0.2" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.Touch/Xmf2.Commons.MvxExtends.Touch.csproj
+++ b/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.Touch/Xmf2.Commons.MvxExtends.Touch.csproj
@@ -55,7 +55,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MvvmCross" Version="6.4.2" />
+    <PackageReference Include="MvvmCross" Version="8.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Xmf2.iOS.Extensions" Version="1.0.7" />
   </ItemGroup>

--- a/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.csproj
+++ b/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends/Xmf2.Commons.MvxExtends.csproj
@@ -4,7 +4,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MvvmCross" Version="6.4.2" />
+    <PackageReference Include="MvvmCross" Version="8.0.2" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Xmf2.Common.Extensions" Version="1.1.13" />
   </ItemGroup>


### PR DESCRIPTION
Update MvvmCross from 6.4.2 to 8.0.2 + migrate Android.Support libraries to AndroidX librairies