### PR TITLE
fix ios scroll space when keyboard disappears

### DIFF
--- a/src/Xmf2.Core.iOS/Helpers/KeyboardScrollHelper.cs
+++ b/src/Xmf2.Core.iOS/Helpers/KeyboardScrollHelper.cs
@@ -116,12 +116,16 @@ namespace Xmf2.Core.iOS.Helpers
 					{
 						scrollView.ContentInset = _contentInset[scrollView];
 						scrollView.ScrollIndicatorInsets = _scrollIndicatorInsets[scrollView];
+						_contentInset.Remove(scrollView);
 					}
 				}
 				else
 				{
-					_contentInset[scrollView] = scrollView.ContentInset;
-					_scrollIndicatorInsets[scrollView] = scrollView.ScrollIndicatorInsets;
+					if (!_contentInset.ContainsKey(scrollView))
+					{
+						_contentInset[scrollView] = scrollView.ContentInset;
+						_scrollIndicatorInsets[scrollView] = scrollView.ScrollIndicatorInsets;
+					}
 
 					scrollView.CenterView(activeView, keyboardFrame);
 				}


### PR DESCRIPTION
Fix iOS ScrollView leaving blank space because of keyboard.

Repro steps:
- Click on 1 TextInput (keyboard opens)
- Click on 1 other TextInput (_contentInset is override by new content inset value)
- Click outside to close keyboard
=> Scroll keep a keyboard size content inset